### PR TITLE
Set default securityContext for nextcloud-metrics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-# Pull Request
-
 ## Description of the change
 
 <!-- Describe the scope of your change - i.e. what the change does. -->
@@ -23,6 +21,7 @@
 
 ## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
 
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
 - [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
 - [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
-- [ ] (optional) Variables are documented in the README.md
+- [ ] (optional) Parameters are documented in the README.md

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v4
         with:
           version: v3.11.1
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.11.1
+          version: v3.14.4
 
       - name: Add dependency chart repos
         run: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -80,7 +80,7 @@ jobs:
 
           # test the helm chart with horizontal pod autoscaling enabled
           - name: Horizontal Pod Autoscaling Enabled
-            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=1 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
+            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=2 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
 
     steps:
       - name: Checkout

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
               - 'charts/nextcloud/values.yaml'
               - 'charts/nextcloud/templates/**'
 
-  lint-test:
+  lint:
     runs-on: ubuntu-22.04
     needs: changes
     if: needs.changes.outputs.src != 'false'
@@ -56,6 +56,36 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
+  test-internal-database:
+    runs-on: ubuntu-22.04
+    needs: [changes, lint]
+    if: needs.changes.outputs.src != 'false'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
@@ -64,3 +94,44 @@ jobs:
         id: install
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}
+
+  test-postgresql-database:
+    runs-on: ubuntu-22.04
+    needs: [changes, lint]
+    if: needs.changes.outputs.src != 'false'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        id: install
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+            ct install --target-branch ${{ github.event.repository.default_branch }} \
+            --helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing123456"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
               - 'charts/nextcloud/templates/**'
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-low
     needs: changes
     if: needs.changes.outputs.src != 'false'
     steps:
@@ -56,10 +56,32 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
-  test-internal-database:
+  run-tests:
     runs-on: ubuntu-22.04
     needs: [changes, lint]
+    # only run this job if there are helm chart file changes
     if: needs.changes.outputs.src != 'false'
+    strategy:
+      # continue with all the other jobs even if one fails
+      fail-fast: false
+      matrix:
+        # each item in this list is a job with an isolated test VM
+        test_cases:
+          # test the plain helm chart with nothing changed
+          - name: 'Default - no custom values'
+
+          # test the helm chart with postgresql subchart enabled
+          - name: PostgreSQL Enabled
+            helm_args: '--helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing12345"'
+
+          # test the helm chart with nginx container enabled
+          - name: Nginx Enabled
+            helm_args: '--helm-extra-set-args "--set=image.flavor=fpm --set=nginx.enabled=true"'
+
+          # test the helm chart with horizontal pod autoscaling enabled
+          - name: Horizontal Pod Autoscaling Enabled
+            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=1 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,48 +112,15 @@ jobs:
         uses: helm/kind-action@v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing (install ${{ matrix.test_cases.name }})
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} ${{ matrix.test_cases.helm_args }}
 
-  test-postgresql-database:
-    runs-on: ubuntu-22.04
-    needs: [changes, lint]
-    if: needs.changes.outputs.src != 'false'
+  summary:
+    runs-on: ubuntu-latest-low
+    needs: [changes, run-tests]
+    if: always()
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.14.4
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.10.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Run chart-testing (install)
-        id: install
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-            ct install --target-branch ${{ github.event.repository.default_branch }} \
-            --helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing123456"
+      - name: Summary
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.run-tests.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -45,7 +45,7 @@ jobs:
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,17 +2,29 @@ name: Lint and Test Charts
 
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'charts/**/README.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - 'README.md'
-
+    paths:
 jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - 'charts/nextcloud/Chart.yaml'
+              - 'charts/nextcloud/values.yaml'
+              - 'charts/nextcloud/templates/**'
+
   lint-test:
     runs-on: ubuntu-22.04
+    needs: changes
+    if: needs.changes.outputs.src != 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.11.1
+          version: v3.14.4
 
       - name: Add dependency chart repos
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
 
       # See https://github.com/helm/chart-releaser-action/issues/6
       - name: Set up Helm
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v4
         with:
           version: v3.11.1
 

--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.12.10
+  version: 15.5.0
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.2.9
+  version: 18.2.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.13.2
-digest: sha256:92fe0891c35c2586cfe3b76154412c188bb75cc0a687e1d771fc4c1cf0f8973d
-generated: "2023-11-11T19:19:38.983179104+01:00"
+  version: 19.5.0
+digest: sha256:4efc098feeb7f4486b7166f1c71b9c54bfee0797663a3339f379d397297303c7
+generated: "2024-06-03T09:51:56.321676+02:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.8
+version: 4.6.9
 appVersion: 29.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.7
+version: 4.6.8
 appVersion: 29.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.2.1
+version: 5.2.2
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 5.2.2
-appVersion: 29.0.3
+version: 5.2.3
+appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 5.0.1
-appVersion: 29.0.2
+version: 5.0.2
+appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.1.0
+version: 5.2.0
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.9
-appVersion: 29.0.0
+version: 4.6.10
+appVersion: 29.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.2.0
+version: 5.2.1
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.10
+version: 4.6.11
 appVersion: 29.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.11
+version: 5.0.0
 appVersion: 29.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,14 +23,14 @@ maintainers:
     email: jeff@billimek.com
 dependencies:
   - name: postgresql
-    version: 12.12.*
+    version: 15.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: mariadb
-    version: 12.2.*
+    version: 18.2.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: mariadb.enabled
   - name: redis
-    version: 17.13.*
+    version: 19.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.2.2
+version: 5.3.0
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.6
-appVersion: 28.0.4
+version: 4.6.7
+appVersion: 29.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.3.0
+version: 5.3.1
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 5.0.0
-appVersion: 29.0.1
+version: 5.0.1
+appVersion: 29.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.0.2
+version: 5.1.0
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -210,46 +210,46 @@ For convenience, we packages the following Bitnami charts for databases (feel fr
 If you choose to use one of the prepackaged Bitnami helm charts, you must configure both the `externalDatabase` parameters, and the parameters for the chart you choose. For instance, if you choose to use the Bitnami PostgreSQL chart that we've prepackaged, you need to also configure all the parameters for `postgresql`. You do not need to use the Bitnami helm charts. If you want to use an already configured database that you have externally, just set `internalDatabase.enabled` to `false`, and configure the `externalDatabase` parameters below.
 
 
-| Parameter                                                            | Description                                                                            | Default               |
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|-----------------------|
-| `internalDatabase.enabled`                                           | Whether to use internal sqlite database                                                | `true`                |
-| `internalDatabase.database`                                          | Name of the existing database                                                          | `nextcloud`           |
-| `externalDatabase.enabled`                                           | Whether to use external database                                                       | `false`               |
-| `externalDatabase.type`                                              | External database type: `mysql`, `postgresql`                                          | `mysql`               |
-| `externalDatabase.host`                                              | Host of the external database in form of `host:port`                                   | `nil`                 |
-| `externalDatabase.database`                                          | Name of the existing database                                                          | `nextcloud`           |
-| `externalDatabase.user`                                              | Existing username in the external db                                                   | `nextcloud`           |
-| `externalDatabase.password`                                          | Password for the above username                                                        | `nil`                 |
-| `externalDatabase.existingSecret.enabled`                            | Whether to use a existing secret or not                                                | `false`               |
-| `externalDatabase.existingSecret.secretName`                         | Name of the existing secret                                                            | `nil`                 |
-| `externalDatabase.existingSecret.usernameKey`                        | Name of the key that contains the username                                             | `nil`                 |
-| `externalDatabase.existingSecret.passwordKey`                        | Name of the key that contains the password                                             | `nil`                 |
-| `externalDatabase.existingSecret.hostKey`                            | Name of the key that contains the database hostname or IP address                      | `nil`                 |
-| `externalDatabase.existingSecret.databaseKey`                        | Name of the key that contains the database name                                        | `nil`                 |
-| `mariadb.enabled`                                                    | Whether to use the MariaDB chart                                                       | `false`               |
-| `mariadb.auth.database`                                              | Database name to create                                                                | `nextcloud`           |
-| `mariadb.auth.username`                                              | Database user to create                                                                | `nextcloud`           |
-| `mariadb.auth.password`                                              | Password for the database                                                              | `changeme`            |
-| `mariadb.auth.rootPassword`                                          | MariaDB admin password                                                                 | `nil`                 |
-| `mariadb.auth.existingSecret`                                        | Use existing secret for MariaDB password details; see values.yaml for more detail      | `''`                  |
-| `mariadb.image.registry`                                             | MariaDB image registry                                                                 | `docker.io`           |
-| `mariadb.image.repository`                                           | MariaDB image repository                                                               | `bitnami/mariadb`     |
-| `mariadb.image.tag`                                                  | MariaDB image tag                                                                      | ``                    |
-| `mariadb.primary.persistence.enabled`                                | Whether or not to Use a PVC on MariaDB primary                                         | `false`               |
-| `mariadb.primary.persistence.existingClaim`                          | Use an existing PVC for MariaDB primary                                                | `nil`                 |
-| `postgresql.enabled`                                                 | Whether to use the PostgreSQL chart                                                    | `false`               |
-| `postgresql.image.registry`                                          | PostgreSQL image registry                                                              | `docker.io`           |
-| `postgresql.image.repository`                                        | PostgreSQL image repository                                                            | `bitnami/postgresql`  |
-| `postgresql.image.tag`                                               | PostgreSQL image tag                                                                   | `15.4.0-debian-11-r10`|
-| `postgresql.global.postgresql.auth.database`                         | Database name to create                                                                | `nextcloud`           |
-| `postgresql.global.postgresql.auth.username`                         | Database user to create                                                                | `nextcloud`           |
-| `postgresql.global.postgresql.auth.password`                         | Password for the database                                                              | `changeme`            |
-| `postgresql.global.postgresql.auth.existingSecret`                   | Name of existing secret to use for PostgreSQL credentials                              | `''`                  |
-| `postgresql.global.postgresql.auth.secretKeys.adminPasswordKey`      | Name of key in existing secret to use for PostgreSQL admin password                    | `''`                  |
-| `postgresql.global.postgresql.auth.secretKeys.userPasswordKey`       | Name of key in existing secret to use for PostgreSQL user password                     | `''`                  |
-| `postgresql.global.postgresql.auth.secretKeys.replicationPasswordKey`| Name of key in existing secret to use for PostgreSQL replication password              | `''`                  |
-| `postgresql.primary.persistence.enabled`                             | Whether or not to use PVC on PostgreSQL primary                                        | `false`               |
-| `postgresql.primary.persistence.existingClaim`                       | Use an existing PVC for PostgreSQL primary                                             | `nil`                 |
+| Parameter                                                             | Description                                                                       | Default                |
+|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------|------------------------|
+| `internalDatabase.enabled`                                            | Whether to use internal sqlite database                                           | `true`                 |
+| `internalDatabase.database`                                           | Name of the existing database                                                     | `nextcloud`            |
+| `externalDatabase.enabled`                                            | Whether to use external database                                                  | `false`                |
+| `externalDatabase.type`                                               | External database type: `mysql`, `postgresql`                                     | `mysql`                |
+| `externalDatabase.host`                                               | Host of the external database in form of `host:port`                              | `nil`                  |
+| `externalDatabase.database`                                           | Name of the existing database                                                     | `nextcloud`            |
+| `externalDatabase.user`                                               | Existing username in the external db                                              | `nextcloud`            |
+| `externalDatabase.password`                                           | Password for the above username                                                   | `nil`                  |
+| `externalDatabase.existingSecret.enabled`                             | Whether to use a existing secret or not                                           | `false`                |
+| `externalDatabase.existingSecret.secretName`                          | Name of the existing secret                                                       | `nil`                  |
+| `externalDatabase.existingSecret.usernameKey`                         | Name of the key that contains the username                                        | `nil`                  |
+| `externalDatabase.existingSecret.passwordKey`                         | Name of the key that contains the password                                        | `nil`                  |
+| `externalDatabase.existingSecret.hostKey`                             | Name of the key that contains the database hostname or IP address                 | `nil`                  |
+| `externalDatabase.existingSecret.databaseKey`                         | Name of the key that contains the database name                                   | `nil`                  |
+| `mariadb.enabled`                                                     | Whether to use the MariaDB chart                                                  | `false`                |
+| `mariadb.auth.database`                                               | Database name to create                                                           | `nextcloud`            |
+| `mariadb.auth.username`                                               | Database user to create                                                           | `nextcloud`            |
+| `mariadb.auth.password`                                               | Password for the database                                                         | `changeme`             |
+| `mariadb.auth.rootPassword`                                           | MariaDB admin password                                                            | `nil`                  |
+| `mariadb.auth.existingSecret`                                         | Use existing secret for MariaDB password details; see values.yaml for more detail | `''`                   |
+| `mariadb.image.registry`                                              | MariaDB image registry                                                            | `docker.io`            |
+| `mariadb.image.repository`                                            | MariaDB image repository                                                          | `bitnami/mariadb`      |
+| `mariadb.image.tag`                                                   | MariaDB image tag                                                                 | ``                     |
+| `mariadb.primary.persistence.enabled`                                 | Whether or not to Use a PVC on MariaDB primary                                    | `false`                |
+| `mariadb.primary.persistence.existingClaim`                           | Use an existing PVC for MariaDB primary                                           | `nil`                  |
+| `postgresql.enabled`                                                  | Whether to use the PostgreSQL chart                                               | `false`                |
+| `postgresql.image.registry`                                           | PostgreSQL image registry                                                         | `docker.io`            |
+| `postgresql.image.repository`                                         | PostgreSQL image repository                                                       | `bitnami/postgresql`   |
+| `postgresql.image.tag`                                                | PostgreSQL image tag                                                              | `15.4.0-debian-11-r10` |
+| `postgresql.global.postgresql.auth.database`                          | Database name to create                                                           | `nextcloud`            |
+| `postgresql.global.postgresql.auth.username`                          | Database user to create                                                           | `nextcloud`            |
+| `postgresql.global.postgresql.auth.password`                          | Password for the database                                                         | `changeme`             |
+| `postgresql.global.postgresql.auth.existingSecret`                    | Name of existing secret to use for PostgreSQL credentials                         | `''`                   |
+| `postgresql.global.postgresql.auth.secretKeys.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL admin password               | `''`                   |
+| `postgresql.global.postgresql.auth.secretKeys.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL user password                | `''`                   |
+| `postgresql.global.postgresql.auth.secretKeys.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL replication password         | `''`                   |
+| `postgresql.primary.persistence.enabled`                              | Whether or not to use PVC on PostgreSQL primary                                   | `false`                |
+| `postgresql.primary.persistence.existingClaim`                        | Use an existing PVC for PostgreSQL primary                                        | `nil`                  |
 
 Is there a missing parameter for one of the Bitnami helm charts listed above? Please feel free to submit a PR to add that parameter in our values.yaml, but be sure to also update this README file :)
 
@@ -261,50 +261,53 @@ Persistent Volume Claims are used to keep the data across deployments. This is k
 Nextcloud will *not* delete the PVCs when uninstalling the helm chart.
 
 
-| Parameter                                                            | Description                                                                            | Default                                      |
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------|
-| `persistence.enabled`                                                | Enable persistence using PVC                                                           | `false`                                      |
-| `persistence.annotations`                                            | PVC annotations                                                                        | `{}`                                         |
-| `persistence.storageClass`                                           | PVC Storage Class for nextcloud volume                                                 | `nil` (uses alpha storage class annotation)  |
-| `persistence.existingClaim`                                          | An Existing PVC name for nextcloud volume                                              | `nil` (uses alpha storage class annotation)  |
-| `persistence.accessMode`                                             | PVC Access Mode for nextcloud volume                                                   | `ReadWriteOnce`                              |
-| `persistence.size`                                                   | PVC Storage Request for nextcloud volume                                               | `8Gi`                                        |
-| `persistence.nextcloudData.enabled`                                  | Create a second PVC for the data folder in nextcloud                                   | `false`                                      |
-| `persistence.nextcloudData.annotations`                              | see `persistence.annotations`                                                          | `{}`                                         |
-| `persistence.nextcloudData.storageClass`                             | see `persistence.storageClass`                                                         | `nil` (uses alpha storage class annotation)  |
-| `persistence.nextcloudData.existingClaim`                            | see `persistence.existingClaim`                                                        | `nil` (uses alpha storage class annotation)  |
-| `persistence.nextcloudData.accessMode`                               | see `persistence.accessMode`                                                           | `ReadWriteOnce`                              |
-| `persistence.nextcloudData.size`                                     | see `persistence.size`                                                                 | `8Gi`                                        |
+| Parameter                                 | Description                                          | Default                                     |
+|-------------------------------------------|------------------------------------------------------|---------------------------------------------|
+| `persistence.enabled`                     | Enable persistence using PVC                         | `false`                                     |
+| `persistence.annotations`                 | PVC annotations                                      | `{}`                                        |
+| `persistence.storageClass`                | PVC Storage Class for nextcloud volume               | `nil` (uses alpha storage class annotation) |
+| `persistence.existingClaim`               | An Existing PVC name for nextcloud volume            | `nil` (uses alpha storage class annotation) |
+| `persistence.accessMode`                  | PVC Access Mode for nextcloud volume                 | `ReadWriteOnce`                             |
+| `persistence.size`                        | PVC Storage Request for nextcloud volume             | `8Gi`                                       |
+| `persistence.nextcloudData.enabled`       | Create a second PVC for the data folder in nextcloud | `false`                                     |
+| `persistence.nextcloudData.annotations`   | see `persistence.annotations`                        | `{}`                                        |
+| `persistence.nextcloudData.storageClass`  | see `persistence.storageClass`                       | `nil` (uses alpha storage class annotation) |
+| `persistence.nextcloudData.existingClaim` | see `persistence.existingClaim`                      | `nil` (uses alpha storage class annotation) |
+| `persistence.nextcloudData.accessMode`    | see `persistence.accessMode`                         | `ReadWriteOnce`                             |
+| `persistence.nextcloudData.size`          | see `persistence.size`                               | `8Gi`                                       |
 
 
 ### Metrics Configurations
 
 We include an optional experimental Nextcloud Metrics exporter from [xperimental/nextcloud-exporter](https://github.com/xperimental/nextcloud-exporter).
 
-| Parameter                              | Description                                                                  | Default                                                      |
-|----------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                      | Start Prometheus metrics exporter                                            | `false`                                                      |
-| `metrics.https`                        | Defines if https is used to connect to nextcloud                             | `false` (uses http)                                          |
-| `metrics.token`                        | Uses token for auth instead of username/password                             | `""`                                                         |
-| `metrics.timeout`                      | When the scrape times out                                                    | `5s`                                                         |
-| `metrics.tlsSkipVerify`                | Skips certificate verification of Nextcloud server                           | `false`                                                      |
-| `metrics.image.repository`             | Nextcloud metrics exporter image name                                        | `xperimental/nextcloud-exporter`                             |
-| `metrics.image.tag`                    | Nextcloud metrics exporter image tag                                         | `0.6.2`                                                      |
-| `metrics.image.pullPolicy`             | Nextcloud metrics exporter image pull policy                                 | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`            | Nextcloud metrics exporter image pull secrets                                | `nil`                                                        |
-| `metrics.podAnnotations`               | Additional annotations for metrics exporter                                  | not set                                                      |
-| `metrics.podLabels`                    | Additional labels for metrics exporter                                       | not set                                                      |
-| `metrics.service.type`                 | Metrics: Kubernetes Service type                                             | `ClusterIP`                                                  |
-| `metrics.service.loadBalancerIP`       | Metrics: LoadBalancerIp for service type LoadBalancer                        | `nil`                                                        |
-| `metrics.service.nodePort`             | Metrics: NodePort for service type NodePort                                  | `nil`                                                        |
-| `metrics.service.annotations`          | Additional annotations for service metrics exporter                          | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
-| `metrics.service.labels`               | Additional labels for service metrics exporter                               | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                                                      |
-| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                     | ``                                                           |
-| `metrics.serviceMonitor.jobLabel`      | Name of the label on the target service to use as the job name in prometheus | ``                                                           |
-| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                  | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                          | ``                                                           |
-| `metrics.serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                          | `{}                                                          |
+| Parameter                              | Description                                                                         | Default                                                      |
+|----------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                      | Start Prometheus metrics exporter                                                   | `false`                                                      |
+| `metrics.replicaCount`                 | Number of nextcloud-metrics pod replicas to deploy                                  | `1`                                                          |
+| `metrics.server`                       | Nextcloud Server URL to get metrics from. If not provided, defaults to service name | `""`                                                         |
+| `metrics.https`                        | Defines if https is used to connect to nextcloud                                    | `false` (uses http)                                          |
+| `metrics.token`                        | Uses token for auth instead of username/password                                    | `""`                                                         |
+| `metrics.timeout`                      | When the scrape times out                                                           | `5s`                                                         |
+| `metrics.tlsSkipVerify`                | Skips certificate verification of Nextcloud server                                  | `false`                                                      |
+| `metrics.info.apps`                    | Enable gathering of apps-related metrics.                                           | `false`                                                      |
+| `metrics.image.repository`             | Nextcloud metrics exporter image name                                               | `xperimental/nextcloud-exporter`                             |
+| `metrics.image.tag`                    | Nextcloud metrics exporter image tag                                                | `0.6.2`                                                      |
+| `metrics.image.pullPolicy`             | Nextcloud metrics exporter image pull policy                                        | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`            | Nextcloud metrics exporter image pull secrets                                       | `nil`                                                        |
+| `metrics.podAnnotations`               | Additional annotations for metrics exporter                                         | not set                                                      |
+| `metrics.podLabels`                    | Additional labels for metrics exporter                                              | not set                                                      |
+| `metrics.service.type`                 | Metrics: Kubernetes Service type                                                    | `ClusterIP`                                                  |
+| `metrics.service.loadBalancerIP`       | Metrics: LoadBalancerIp for service type LoadBalancer                               | `nil`                                                        |
+| `metrics.service.nodePort`             | Metrics: NodePort for service type NodePort                                         | `nil`                                                        |
+| `metrics.service.annotations`          | Additional annotations for service metrics exporter                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
+| `metrics.service.labels`               | Additional labels for service metrics exporter                                      | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator        | `false`                                                      |
+| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                            | ``                                                           |
+| `metrics.serviceMonitor.jobLabel`      | Name of the label on the target service to use as the job name in prometheus        | ``                                                           |
+| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                         | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                                 | ``                                                           |
+| `metrics.serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                                 | `{}                                                          |
 
 
 
@@ -394,7 +397,7 @@ nginx
 
 ### Service discovery with nginx and ingress
 
-For service discovery (CalDAV, CardDAV, webfinger, nodeinfo) to work you need to add redirects to your ingress.  
+For service discovery (CalDAV, CardDAV, webfinger, nodeinfo) to work you need to add redirects to your ingress.
 If you use the [ingress-nginx](https://github.com/kubernetes/ingress-nginx) you can use the following server snippet annotation:
 
 <!-- Keep this in sync with the values.yaml -->
@@ -515,10 +518,10 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ recognize:down
 ```
 
 # Backups
-Check out the [official Nextcloud backup docs](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html). For your files, if you're using persistent volumes, and you'd like to back up to s3 backed storage (such as minio), consider using [k8up](https://github.com/k8up-io/k8up) or [velero](https://github.com/vmware-tanzu/velero). 
+Check out the [official Nextcloud backup docs](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html). For your files, if you're using persistent volumes, and you'd like to back up to s3 backed storage (such as minio), consider using [k8up](https://github.com/k8up-io/k8up) or [velero](https://github.com/vmware-tanzu/velero).
 
 # Upgrades
-Since this chart utilizes the [nextcloud/docker](https://github.com/nextcloud/docker) image, provided you are using persistent volumes, [upgrades of your Nextcloud server are handled automatically](https://github.com/nextcloud/docker#update-to-a-newer-version) from one version to the next, however, you can only upgrade one major version at a time. For example, if you want to upgrade from version `25` to `27`, you will have to upgrade from version `25` to `26`, then from `26` to `27`. Since our docker tag is set via the [`appVersion` in `Chart.yaml`](https://github.com/nextcloud/helm/blob/main/charts/nextcloud/Chart.yaml#L4), you'll need to make sure you gradually upgrade the helm chart if you have missed serveral app versions. 
+Since this chart utilizes the [nextcloud/docker](https://github.com/nextcloud/docker) image, provided you are using persistent volumes, [upgrades of your Nextcloud server are handled automatically](https://github.com/nextcloud/docker#update-to-a-newer-version) from one version to the next, however, you can only upgrade one major version at a time. For example, if you want to upgrade from version `25` to `27`, you will have to upgrade from version `25` to `26`, then from `26` to `27`. Since our docker tag is set via the [`appVersion` in `Chart.yaml`](https://github.com/nextcloud/helm/blob/main/charts/nextcloud/Chart.yaml#L4), you'll need to make sure you gradually upgrade the helm chart if you have missed serveral app versions.
 
 ⚠️ *Before Upgrading Nextcloud or the attached database, always make sure you take [backups](#backups)!*
 

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -147,6 +147,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nginx.config.custom`                                      | Specify a custom config for nginx                                                                   | `{}`                       |
 | `nginx.resources`                                          | nginx resources                                                                                     | `{}`                       |
 | `nginx.securityContext`                                    | Optional security context for the nginx container                                                   | `nil`                      |
+| `nginx.extraEnv`                                           | Optional environment variables for the nginx container                                              | `nil`                      |
 | `lifecycle.postStartCommand`                               | Specify deployment lifecycle hook postStartCommand                                                  | `nil`                      |
 | `lifecycle.preStopCommand`                                 | Specify deployment lifecycle hook preStopCommand                                                    | `nil`                      |
 | `redis.enabled`                                            | Whether to install/use redis for locking                                                            | `false`                    |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -155,6 +155,9 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `redis.auth.password`                                      | The password redis uses                                                                             | `''`                       |
 | `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                              | `''`                       |
 | `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                                   | `''`                       |
+| `redis.global.storageClass`                                | PVC Storage Class  for both Redis&reg; master and replica Persistent Volumes                        | `''`                       |
+| `redis.master.persistence.enabled`                         | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                        | `true`                     |
+| `redis.replica.persistence.enabled`                        | Enable persistence on Redis&reg; replica nodes using Persistent Volume Claims                       | `true`                     |
 | `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                                         | `false`                    |
 | `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                        | `nil`                      |
 | `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                          | `nil`                      |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -202,6 +202,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `deploymentAnnotations`                                    | Annotations to be added at 'deployment' level                                                       | not set                    |
 | `podLabels`                                                | Labels to be added at 'pod' level                                                                   | not set                    |
 | `podAnnotations`                                           | Annotations to be added at 'pod' level                                                              | not set                    |
+| `dnsConfig`                                                | Custom dnsConfig for nextcloud containers                                                           | `{}`                       |
 
 
 ### Database Configurations

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -22,15 +22,24 @@ helm install my-release nextcloud/nextcloud
 * [Cron jobs](#cron-jobs)
 * [Multiple config.php file](#multiple-configphp-file)
 * [Using nginx](#using-nginx)
+    * [Service discovery with nginx and ingress](#service-discovery-with-nginx-and-ingress)
 * [Preserving Source IP](#preserving-source-ip)
 * [Hugepages](#hugepages)
 * [HPA (Clustering)](#hpa-clustering)
+* [Adjusting PHP ini values](#adjusting-php-ini-values)
 * [Running `occ` commands](#running-occ-commands)
     * [Putting Nextcloud into maintanence mode](#putting-nextcloud-into-maintanence-mode)
     * [Downloading models for recognize](#downloading-models-for-recognize)
 * [Backups](#backups)
 * [Upgrades](#upgrades)
 * [Troubleshooting](#troubleshooting)
+    * [Logging](#logging)
+        * [Changing the logging behavior](#changing-the-logging-behavior)
+        * [Viewing the logs](#viewing-the-logs)
+            * [Exec into the kubernetes pod:](#exec-into-the-kubernetes-pod)
+            * [Then look for the `nextcloud.log` file with tail or cat:](#then-look-for-the-nextcloudlog-file-with-tail-or-cat)
+            * [Copy the log file to your local machine:](#copy-the-log-file-to-your-local-machine)
+        * [Sharing the logs](#sharing-the-logs)
 
 ## Introduction
 
@@ -493,6 +502,20 @@ persistence:
   enabled: true
   accessMode: ReadWriteMany
 ```
+
+## Adjusting PHP ini values
+
+Sometimes you may need special [`php.ini`](https://www.php.net/manual/en/ini.list.php) values. For instance, perhaps your setup requires a bit more memory. You can add additional `php.ini` files in the values.yaml by providing `nextcloud.phpConfigs.NAME_OF_FILE`. Here's an examples:
+
+```yaml
+nextcloud:
+  phpConfigs:
+    zz-memory_limit.ini: |-
+      memory_limit=512M
+```
+
+> [!Note]
+> Be sure to prefix your file name with `zz` to ensure it is loaded at the end.
 
 
 ## Running `occ` commands

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -203,7 +203,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `startupProbe.timeoutSeconds`                              | When the probe times out                                                                            | `5`                        |
 | `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                          | `30`                       |
 | `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler                                                         | `false`                    |
+| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler. If set to `true`, ignores `replicaCount`.              | `false`                    |
 | `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                                | `60`                       |
 | `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `1`                        |
 | `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `10`                       |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -165,6 +165,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.securityContext`                                  | Optional security context for cron jobs sidecar                                                     | `nil`                      |
 | `service.type`                                             | Kubernetes Service type                                                                             | `ClusterIP`                |
 | `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                                        | `""`                       |
+| `service.annotations`                                      | Annotations for service type                                                                        | `{}`                       |
 | `service.nodePort`                                         | NodePort for service type NodePort                                                                  | `nil`                      |
 | `service.ipFamilies`                                       | Set ipFamilies as in k8s service objects                                                            | `nil`                      |
 | `service.ipFamyPolicy`                                     | define IP protocol bindings as in k8s service objects                                               | `nil`                      |

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -178,7 +178,7 @@ Create environment variables used to configure the nextcloud container as well a
       name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
       key: {{ .Values.nextcloud.existingSecret.passwordKey }}
 - name: NEXTCLOUD_TRUSTED_DOMAINS
-  value: {{ .Values.nextcloud.host }}
+  value: {{ .Values.nextcloud.host }}{{ if .Values.metrics.enabled }} {{ template "nextcloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
 {{- if ne (int .Values.nextcloud.update) 0 }}
 - name: NEXTCLOUD_UPDATE
   value: {{ .Values.nextcloud.update | quote }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -293,6 +293,10 @@ spec:
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
+          {{- with .Values.nextcloud.mariadbInitContainerSecurityContext }}
+          securityContext:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: MYSQL_USER
               valueFrom:
@@ -311,6 +315,10 @@ spec:
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+          {{- with .Values.nextcloud.postgresqlInitContainerSecurityContext }}
+          securityContext:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POSTGRES_USER
               valueFrom:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -149,6 +149,10 @@ spec:
         - name: {{ .Chart.Name }}-nginx
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          {{- with .Values.nginx.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -293,7 +293,7 @@ spec:
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
-          {{- with .Values.nextcloud.mariadbInitContainerSecurityContext }}
+          {{- with .Values.nextcloud.mariaDbInitContainer.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -315,7 +315,7 @@ spec:
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-          {{- with .Values.nextcloud.postgresqlInitContainerSecurityContext }}
+          {{- with .Values.nextcloud.postgreSqlInitContainer.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -396,3 +396,7 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -295,7 +295,7 @@ spec:
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
           {{- with .Values.nextcloud.mariadbInitContainerSecurityContext }}
           securityContext:
-              {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: MYSQL_USER
@@ -317,7 +317,7 @@ spec:
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
           {{- with .Values.nextcloud.postgresqlInitContainerSecurityContext }}
           securityContext:
-              {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: POSTGRES_USER

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.nextcloud.strategy | nindent 4 }}
   selector:

--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -59,12 +59,19 @@ spec:
                   key: {{ .Values.nextcloud.existingSecret.passwordKey }}
             {{- end }}
             # NEXTCLOUD_SERVER is used by metrics-exporter to reach the Nextcloud (K8s-)Service to grab the serverinfo api endpoint
+            {{- if not .Values.metrics.server }}
             - name: NEXTCLOUD_SERVER # deployment.namespace.svc.cluster.local
               value: "http{{ if .Values.metrics.https }}s{{ end }}://{{ template "nextcloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+            {{- else }}
+            - name: NEXTCLOUD_SERVER
+              value: {{ .Values.metrics.server }}
+            {{- end }}
             - name: NEXTCLOUD_TIMEOUT
               value: {{ .Values.metrics.timeout }}
             - name: NEXTCLOUD_TLS_SKIP_VERIFY
               value: {{ .Values.metrics.tlsSkipVerify | quote }}
+            - name: NEXTCLOUD_INFO_APPS
+              value: {{ .Values.metrics.info.apps | quote }}
           ports:
             - name: metrics
               containerPort: 9205

--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -75,4 +75,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
 {{- end }}

--- a/charts/nextcloud/templates/secrets.yaml
+++ b/charts/nextcloud/templates/secrets.yaml
@@ -17,9 +17,9 @@ data:
   {{- else }}
   nextcloud-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
-  {{- with .Values.metrics.token }}
-  nextcloud-token: {{ . | b64enc | quote }}
-  {{- else }}
+  {{- if and .Values.metrics.enabled .Values.metrics.token }}
+  nextcloud-token: {{ .Values.metrics.token | b64enc | quote }}
+  {{- else if and .Values.metrics.enabled (not .Values.metrics.token) }}
   nextcloud-token: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if .Values.nextcloud.mail.enabled }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "nextcloud.fullname" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}
     helm.sh/chart: {{ include "nextcloud.chart" . }}
@@ -17,7 +21,7 @@ spec:
   {{- end }}
   {{- end }}
   {{- with .Values.service.ipFamilies }}
-  ipFamilies: 
+  ipFamilies:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.service.ipFamilyPolicy }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -213,18 +213,23 @@ nextcloud:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: false
 
-  # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
-  mariadbInitContainerSecurityContext: {}
-
-  # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
-  postgresqlInitContainerSecurityContext: {}
-
   # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
   podSecurityContext: {}
   #   runAsUser: 33
   #   runAsGroup: 33
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: false
+
+  # Settings for the MariaDB init container
+  mariaDbInitContainer:
+    # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+    securityContext: {}
+
+  # Settings for the PostgreSQL init container
+  postgreSqlInitContainer:
+    # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+    securityContext: {}
+
 
 nginx:
   ## You need to set an fpm version of the image for nextcloud if you want to use nginx!

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -410,6 +410,9 @@ service:
   port: 8080
   loadBalancerIP: ""
   nodePort: nil
+  annotations: {}
+    ## Insert your annotations such as below
+    # test/test: pumuckel
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -497,6 +497,9 @@ metrics:
   enabled: false
 
   replicaCount: 1
+  # Optional: becomes NEXTCLOUD_SERVER env var in the nextcloud-exporter container.
+  # Without it, we will use the full name of the nextcloud service
+  server: ""
   # The metrics exporter needs to know how you serve Nextcloud either http or https
   https: false
   # Use API token if set, otherwise fall back to password authentication
@@ -506,6 +509,10 @@ metrics:
   timeout: 5s
   # if set to true, exporter skips certificate verification of Nextcloud server.
   tlsSkipVerify: false
+  info:
+    # Optional: becomes NEXTCLOUD_INFO_APPS env var in the nextcloud-exporter container.
+    # Enables gathering of apps-related metrics. Defaults to false
+    apps: false
 
   image:
     repository: xperimental/nextcloud-exporter

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -371,6 +371,15 @@ redis:
     existingSecret: ""
     # Password key to be retrieved from existing secret
     existingSecretPasswordKey: ""
+  # Since Redis is used for caching only, you might want to use a storageClass with different reclaim policy and backup settings
+  global:
+    storageClass: ""
+  master:
+    persistence:
+      enabled: true
+  replica:
+    persistence:
+      enabled: true
 
 
 ## Cronjob to execute Nextcloud background tasks

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -213,6 +213,12 @@ nextcloud:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: false
 
+  # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+  mariadbInitContainerSecurityContext: {}
+
+  # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+  postgresqlInitContainerSecurityContext: {}
+
   # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
   podSecurityContext: {}
   #   runAsUser: 33

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -245,6 +245,11 @@ nginx:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
+  ## Extra environment variables
+  extraEnv: []
+  #  - name: SOME_ENV
+  #    value: ENV_VALUE
+
 internalDatabase:
   enabled: true
   name: nextcloud

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -502,6 +502,12 @@ tolerations: []
 
 affinity: {}
 
+dnsConfig: {}
+# Custom dns config for Nextcloud containers.
+# You can for example configure ndots. This may be needed in some clusters with alpine images.
+# options:
+#   - name: ndots
+#     value: "1"
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
Sets best defaults for securityContext on nextcloud-metrics pod and container.

# Pull Request

## Description of the change

Add defaults to the deployment of nextcloud-metrics with selections for securityContext options on both pod and container.

## Benefits

Clusters with higher security configurations can run nextcloud with metrics enabled.

## Possible drawbacks

Unknown, if any.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
